### PR TITLE
feat: Docker setup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.env
+.env.*
+node_modules
+dist
+docs
+scripts
+docker
+*.md
+.gitignore
+.github
+.claude
+.gitnexus
+biome.json
+vitest.config.ts
+Justfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM node:22-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY package*.json ./
+# Include devDependencies — tsx is required to run TypeScript source directly
+RUN npm ci
+
+COPY src/ ./src/
+COPY tsconfig.json ./
+
+ENV LOG_DIR=/var/log/steward \
+    WORK_DIR=/tmp/repo
+
+RUN mkdir -p /var/log/steward \
+    && addgroup --system steward \
+    && adduser --system --ingroup steward steward \
+    && chown steward:steward /var/log/steward
+
+USER steward
+
+CMD ["node", "--import", "tsx/esm", "src/index.ts"]

--- a/Justfile
+++ b/Justfile
@@ -48,3 +48,15 @@ clean:
 
 # Reinstall from scratch
 fresh: clean install
+
+# Build Docker image
+docker-build:
+    docker build -t steward:latest .
+
+# Run via Docker with full network access (required for GitHub + Anthropic APIs)
+docker-run:
+    DOCKER_NETWORK=bridge docker compose up --no-build
+
+# End-to-end container smoke test (no real credentials required)
+docker-smoke:
+    bash scripts/docker-smoke-test.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  steward:
+    build: .
+    image: steward:latest
+    env_file: .env
+    # Security default: no outbound network.
+    # For real runs, set DOCKER_NETWORK=bridge (or the network name) in your shell
+    # before running docker compose, or use: just docker-run
+    network_mode: "${DOCKER_NETWORK:-none}"
+    volumes:
+      - steward-logs:${LOG_DIR:-/var/log/steward}
+    # Rotate container stdout/stderr logs (runs.jsonl is rotated via logrotate.conf)
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+volumes:
+  steward-logs:

--- a/docker/logrotate.conf
+++ b/docker/logrotate.conf
@@ -1,0 +1,25 @@
+# Logrotate config for steward's runs.jsonl on the host volume.
+#
+# Install on the host:
+#   sudo cp docker/logrotate.conf /etc/logrotate.d/steward
+#
+# Or run manually:
+#   logrotate --state /tmp/steward-logrotate.state docker/logrotate.conf
+#
+# Adjust the path below if LOG_DIR is overridden.
+
+/var/log/steward/runs.jsonl {
+    # Rotate when file exceeds 50 MB, and daily regardless
+    size 50M
+    daily
+    # Keep 10 rotated files (~500 MB max)
+    rotate 10
+    compress
+    delaycompress
+    missingok
+    notifempty
+    # Truncate in place so the running container's file descriptor stays valid
+    copytruncate
+    # Create new log file with correct permissions for the steward user
+    create 0640 root root
+}

--- a/scripts/docker-smoke-test.sh
+++ b/scripts/docker-smoke-test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# End-to-end container smoke test.
+# Builds the image, runs with --network none and stub credentials,
+# and verifies the container starts and exits with a controlled failure
+# (network/auth error), not a crash.
+set -euo pipefail
+
+IMAGE="steward:smoke-test"
+PASS=0
+FAIL=1
+
+echo "=== steward docker smoke test ==="
+
+echo ""
+echo "--- Building image ---"
+docker build --quiet -t "$IMAGE" .
+echo "Image built: $IMAGE"
+
+echo ""
+echo "--- Running container (--network none, stub credentials) ---"
+# The container should: start up, attempt GitHub API validation, fail gracefully.
+set +e
+output=$(docker run --rm \
+    --network none \
+    -e GITHUB_TOKEN=smoke-test-token \
+    -e ANTHROPIC_API_KEY=smoke-test-key \
+    -e GITHUB_REPO=smoke/test \
+    -e LOG_DIR=/tmp/steward-smoke-logs \
+    "$IMAGE" 2>&1)
+exit_code=$?
+set -e
+
+echo "Exit code: $exit_code"
+echo "Output:"
+echo "$output"
+echo ""
+
+# Expect non-zero exit (app can't reach GitHub with --network none)
+if [ "$exit_code" -eq 0 ]; then
+    echo "FAIL: container exited 0 — expected failure with no network/real credentials"
+    exit $FAIL
+fi
+
+# Expect a controlled startup message, not a crash (no unhandled exception / node crash)
+if echo "$output" | grep -qE "^\[steward\]"; then
+    echo "PASS: container started and failed gracefully ([steward] output found)"
+else
+    echo "FAIL: no [steward] startup output found — container may have crashed before running"
+    exit $FAIL
+fi
+
+# Ensure it's not a node crash (would show "node: --import" or uncaught exception)
+if echo "$output" | grep -qE "^node:|SyntaxError:|Cannot find module"; then
+    echo "FAIL: node startup error detected"
+    exit $FAIL
+fi
+
+echo ""
+echo "=== Smoke test passed ==="
+exit $PASS


### PR DESCRIPTION
Closes #2

## Summary
- `Dockerfile` — `node:22-slim` + git, non-root `steward` user, all secrets via env (nothing baked in)
- `docker-compose.yml` — `steward-logs` volume at `$LOG_DIR`, `network_mode: none` security default (override with `DOCKER_NETWORK=bridge`), json-file log rotation for stdout (10 MB / 5 files)
- `docker/logrotate.conf` — size (50 MB) + daily rotation for `runs.jsonl` using `copytruncate` so the container's file descriptor stays valid; install to `/etc/logrotate.d/steward` on the host
- `.dockerignore` — excludes `.env`, `node_modules`, `.git`, docs, tests
- `scripts/docker-smoke-test.sh` — builds image, runs with `--network none` + stub credentials, asserts `[steward]` startup output and graceful non-zero exit (no node crash)
- `Justfile` — `docker-build`, `docker-run` (sets `DOCKER_NETWORK=bridge`), `docker-smoke`

## Test plan
- [ ] `just docker-build` — image builds cleanly
- [ ] `just docker-smoke` — smoke test passes
- [ ] `just docker-run` — requires a valid `.env`; container starts, connects to GitHub, exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)