### PR TITLE
feat: webhook-loop server mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,7 @@ node_modules
 dist
 docs
 scripts
-docker
+docker/logrotate.conf
 *.md
 .gitignore
 .github

--- a/Justfile
+++ b/Justfile
@@ -19,6 +19,10 @@ run:
 dev:
     pnpm --filter @steward/runner dev
 
+# Run webhook-loop in dev mode (requires WEBHOOK_SECRET in .env)
+webhook-dev:
+    pnpm --filter @steward/webhook-loop dev
+
 # Run tests
 test:
     pnpm -r test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,5 +18,27 @@ services:
         max-size: "10m"
         max-file: "5"
 
+  steward-webhook:
+    build:
+      context: .
+      dockerfile: packages/runner/Dockerfile
+    image: steward:latest
+    env_file: .env
+    environment:
+      STEWARD_MODE: webhook
+      # PORT: 3000          # default
+      # WEBHOOK_SECRET: ""  # required
+      # WEBHOOK_EVENTS: "issues,issue_comment,pull_request_review"
+    network_mode: "${DOCKER_NETWORK:-bridge}"
+    ports:
+      - "${PORT:-3000}:${PORT:-3000}"
+    volumes:
+      - steward-logs:${LOG_DIR:-/var/log/steward}
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
+
 volumes:
   steward-logs:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ "${STEWARD_MODE}" = "webhook" ]; then
+    exec node --import tsx/esm packages/webhook-loop/src/index.ts
+else
+    exec node --import tsx/esm packages/runner/src/bin.ts
+fi

--- a/packages/runner/Dockerfile
+++ b/packages/runner/Dockerfile
@@ -15,12 +15,14 @@ COPY packages/auth/package.json ./packages/auth/
 COPY packages/config/package.json ./packages/config/
 COPY packages/gh-client/package.json ./packages/gh-client/
 COPY packages/runner/package.json ./packages/runner/
+COPY packages/webhook-loop/package.json ./packages/webhook-loop/
 
 # Include devDependencies — tsx is required to run TypeScript source directly
 RUN pnpm install --frozen-lockfile
 
 COPY tsconfig.base.json ./
 COPY packages/ ./packages/
+COPY docker/entrypoint.sh ./docker/entrypoint.sh
 
 ENV LOG_DIR=/var/log/steward \
     WORK_DIR=/tmp/repo
@@ -32,4 +34,4 @@ RUN mkdir -p /var/log/steward \
 
 USER steward
 
-CMD ["node", "--import", "tsx/esm", "packages/runner/src/index.ts"]
+ENTRYPOINT ["./docker/entrypoint.sh"]

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -4,8 +4,8 @@
 	"type": "module",
 	"main": "./src/index.ts",
 	"scripts": {
-		"start": "node --import tsx/esm src/index.ts",
-		"dev": "node --env-file=../../.env --import tsx/esm src/index.ts",
+		"start": "node --import tsx/esm src/bin.ts",
+		"dev": "node --env-file=../../.env --import tsx/esm src/bin.ts",
 		"typecheck": "tsc --noEmit",
 		"test": "vitest run --passWithNoTests",
 		"test:watch": "vitest"

--- a/packages/runner/src/bin.ts
+++ b/packages/runner/src/bin.ts
@@ -1,0 +1,3 @@
+import { main } from "./index.js";
+
+main();

--- a/packages/runner/src/index.ts
+++ b/packages/runner/src/index.ts
@@ -8,7 +8,15 @@ import { Agent } from "./agent.js";
 import { Logger } from "./logger.js";
 import { validate } from "./validate.js";
 
-async function main(): Promise<void> {
+export { resolveGitHubToken } from "@steward/auth";
+export type { EnvConfig, RepoConfig } from "@steward/config";
+export { loadEnvConfig } from "@steward/config";
+export { Agent } from "./agent.js";
+export { Logger } from "./logger.js";
+export type { ValidationResult } from "./validate.js";
+export { validate } from "./validate.js";
+
+export async function main(): Promise<void> {
 	// Resolve GitHub token first — may involve an async App token exchange
 	let githubToken: string;
 	try {
@@ -84,5 +92,3 @@ async function main(): Promise<void> {
 	clearTimeout(timeoutHandle);
 	process.exit(0);
 }
-
-main();

--- a/packages/webhook-loop/package.json
+++ b/packages/webhook-loop/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@steward/webhook-loop",
+	"version": "0.1.0",
+	"type": "module",
+	"scripts": {
+		"start": "node --import tsx/esm src/index.ts",
+		"dev": "node --env-file=../../.env --import tsx/esm src/index.ts",
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run --passWithNoTests",
+		"test:watch": "vitest"
+	},
+	"dependencies": {
+		"@steward/runner": "workspace:*"
+	},
+	"devDependencies": {
+		"@types/node": "^22.15.2",
+		"tsx": "^4.19.3",
+		"typescript": "^5.8.3",
+		"vitest": "^4.1.4"
+	}
+}

--- a/packages/webhook-loop/src/index.ts
+++ b/packages/webhook-loop/src/index.ts
@@ -1,0 +1,173 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import {
+	createServer,
+	type IncomingMessage,
+	type ServerResponse,
+} from "node:http";
+import {
+	Agent,
+	type EnvConfig,
+	Logger,
+	loadEnvConfig,
+	type RepoConfig,
+	resolveGitHubToken,
+	validate,
+} from "@steward/runner";
+
+const PORT = parseInt(process.env.PORT ?? "3000", 10);
+const WEBHOOK_SECRET = process.env.WEBHOOK_SECRET ?? "";
+const WEBHOOK_EVENTS = (
+	process.env.WEBHOOK_EVENTS ?? "issues,issue_comment,pull_request_review"
+)
+	.split(",")
+	.map((s) => s.trim())
+	.filter(Boolean);
+
+let agentRunning = false;
+
+function verifySignature(secret: string, body: Buffer, sig: string): boolean {
+	const expected = `sha256=${createHmac("sha256", secret).update(body).digest("hex")}`;
+	try {
+		return timingSafeEqual(Buffer.from(expected), Buffer.from(sig));
+	} catch {
+		return false;
+	}
+}
+
+function readBody(req: IncomingMessage): Promise<Buffer> {
+	return new Promise((resolve, reject) => {
+		const chunks: Buffer[] = [];
+		req.on("data", (chunk: Buffer) => chunks.push(chunk));
+		req.on("end", () => resolve(Buffer.concat(chunks)));
+		req.on("error", reject);
+	});
+}
+
+function handleHook(
+	req: IncomingMessage,
+	res: ServerResponse,
+	env: EnvConfig,
+	repoConfig: RepoConfig,
+): void {
+	readBody(req)
+		.then((body) => {
+			const sig = (req.headers["x-hub-signature-256"] as string) ?? "";
+			if (!verifySignature(WEBHOOK_SECRET, body, sig)) {
+				res.writeHead(401).end();
+				return;
+			}
+
+			const event = (req.headers["x-github-event"] as string) ?? "";
+			if (!WEBHOOK_EVENTS.includes(event)) {
+				res.writeHead(200).end();
+				return;
+			}
+
+			// Acknowledge before any async work
+			res.writeHead(202).end();
+
+			if (agentRunning) {
+				process.stderr.write(
+					`[steward] event=${event} dropped — agent already running\n`,
+				);
+				return;
+			}
+
+			agentRunning = true;
+			const runLogger = new Logger(env.githubRepo, env.logDir);
+			process.stderr.write(
+				`[steward] event=${event} starting run_id=${runLogger.runId}\n`,
+			);
+
+			const runtimeMs = repoConfig.limits.runtimeSeconds * 1000;
+			const agent = new Agent(env, repoConfig, runLogger);
+
+			Promise.race([
+				agent.run(),
+				new Promise<never>((_, reject) =>
+					setTimeout(
+						() =>
+							reject(
+								new Error(`run exceeded ${repoConfig.limits.runtimeSeconds}s`),
+							),
+						runtimeMs,
+					),
+				),
+			])
+				.then(() => {
+					process.stderr.write(
+						`[steward] run_id=${runLogger.runId} completed\n`,
+					);
+				})
+				.catch((e: unknown) => {
+					const msg = e instanceof Error ? e.message : String(e);
+					runLogger.write("error", "error", { error: msg });
+					process.stderr.write(
+						`[steward] run_id=${runLogger.runId} error: ${msg}\n`,
+					);
+				})
+				.finally(() => {
+					agentRunning = false;
+				});
+		})
+		.catch(() => {
+			res.writeHead(400).end();
+		});
+}
+
+export async function main(): Promise<void> {
+	if (!WEBHOOK_SECRET) {
+		process.stderr.write(
+			"[steward] WEBHOOK_SECRET is required in webhook mode\n",
+		);
+		process.exit(1);
+	}
+
+	let githubToken: string;
+	try {
+		githubToken = await resolveGitHubToken();
+	} catch (e: unknown) {
+		process.stderr.write(`[steward] Auth error: ${e}\n`);
+		process.exit(1);
+	}
+
+	let env: EnvConfig;
+	try {
+		env = loadEnvConfig(githubToken);
+	} catch (e: unknown) {
+		process.stderr.write(`[steward] Config error: ${e}\n`);
+		process.exit(1);
+	}
+
+	// validate() runs once at startup, not per-event
+	const startupLogger = new Logger(env.githubRepo, env.logDir);
+	process.stderr.write(
+		`[steward] webhook-loop startup run_id=${startupLogger.runId} repo=${env.githubRepo}\n`,
+	);
+
+	const validationResult = await validate(env);
+	if (!validationResult.ok || !validationResult.repoConfig) {
+		startupLogger.write("validation_failed", "error", {
+			error: validationResult.error,
+		});
+		process.stderr.write(
+			`[steward] Validation failed: ${validationResult.error}\n`,
+		);
+		process.exit(1);
+	}
+	const repoConfig: RepoConfig = validationResult.repoConfig;
+
+	const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+		if (req.method === "POST" && req.url === "/hook") {
+			handleHook(req, res, env, repoConfig);
+		} else {
+			res.writeHead(404).end();
+		}
+	});
+
+	server.listen(PORT, () => {
+		process.stderr.write(`[steward] webhook-loop listening on :${PORT}\n`);
+	});
+}
+
+main();

--- a/packages/webhook-loop/tsconfig.json
+++ b/packages/webhook-loop/tsconfig.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.base.json",
+	"compilerOptions": {
+		"rootDir": "src",
+		"outDir": "dist"
+	},
+	"include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,25 @@ importers:
         specifier: ^4.1.4
         version: 4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
 
+  packages/webhook-loop:
+    dependencies:
+      '@steward/runner':
+        specifier: workspace:*
+        version: link:../runner
+    devDependencies:
+      '@types/node':
+        specifier: ^22.15.2
+        version: 22.19.17
+      tsx:
+        specifier: ^4.19.3
+        version: 4.21.0
+      typescript:
+        specifier: ^5.8.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.5(@types/node@22.19.17)(vite@8.0.10(@types/node@22.19.17)(esbuild@0.27.7)(tsx@4.21.0))
+
 packages:
 
   '@anthropic-ai/sdk@0.39.0':


### PR DESCRIPTION
Closes #4

## Summary

- Adds `@steward/webhook-loop` — a long-running HTTP server that triggers agent runs from GitHub webhooks
- `POST /hook` with `X-Hub-Signature-256` HMAC verification, configurable event filter (`WEBHOOK_EVENTS`), and a mutex that drops events while the agent is busy
- Per-run wall-clock timeout kills only the current run; the server process stays up
- `validate()` runs once at startup, not per-event
- `STEWARD_MODE=webhook` dispatched via `docker/entrypoint.sh`; GHA one-shot path is untouched

**Runner refactor (non-breaking):**
- `src/index.ts` is now the library entry point — exports `Agent`, `Logger`, `validate`, `main`, plus re-exports the auth/config surface so `@steward/webhook-loop` has a single dependency
- `src/bin.ts` is the thin executable (calls `main()`)

## Test plan

- [x] `pnpm -r typecheck` passes
- [x] `just docker-build` builds successfully
- [ ] Send a test webhook (`issues` event) with correct HMAC → agent run starts, 202 returned
- [ ] Send a webhook while agent is running → event dropped and logged, 202 returned
- [ ] Send a webhook with wrong HMAC → 401 returned
- [ ] Send an unfiltered event type → 200 returned, no run
- [ ] `STEWARD_MODE` unset → one-shot GHA behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)